### PR TITLE
Minor clean up, infinite loop fix and add some missing simple functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bincode"
 version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,6 +904,7 @@ name = "photon"
 version = "0.1.0"
 dependencies = [
  "base16ct",
+ "base64",
  "bincode",
  "curl",
  "curl-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,7 +905,6 @@ dependencies = [
  "lazy_static",
  "lz4",
  "md-5",
- "openssl-probe",
  "photon_dsl",
  "rand",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 opt-level = 1
 
 [profile.release]
-lto = "thin"
+lto = true
 strip = true
 panic = "abort"
 # optimize for size, brings resulting binary size from e.g. 3MB -> 2.6MB, *slightly* slower binary, but worth it IMO

--- a/photon-cli/src/main.rs
+++ b/photon-cli/src/main.rs
@@ -1,7 +1,7 @@
 use std::{sync::Mutex, time::Instant};
 
 use clap::Parser;
-use photon::set_config;
+use photon::{health_check, set_config};
 use photon::template_executor::{ExecutionOptions, ScanError};
 use photon::{template_executor::TemplateExecutor, template_loader::TemplateLoader};
 
@@ -41,6 +41,11 @@ fn main() {
     let templ_loader = TemplateLoader::load_from_path(&args.templates);
 
     let base_url = &args.url;
+
+    if let Err(err) = health_check(&base_url) {
+        println!("Healthcheck failed: {}", err.description());
+        return;
+    }
 
     let last_reqs = Mutex::from(0);
     let stopwatch = Mutex::from(Instant::now());

--- a/photon-cli/src/main.rs
+++ b/photon-cli/src/main.rs
@@ -1,8 +1,8 @@
 use std::{sync::Mutex, time::Instant};
 
 use clap::Parser;
-use photon::{health_check, set_config};
 use photon::template_executor::{ExecutionOptions, ScanError};
+use photon::{health_check, set_config};
 use photon::{template_executor::TemplateExecutor, template_loader::TemplateLoader};
 
 #[derive(Parser, Debug)]

--- a/photon/Cargo.toml
+++ b/photon/Cargo.toml
@@ -23,7 +23,6 @@ rand = "0.8.5"
 bincode = "2.0.0-rc.3"
 lz4 = "1.28.0"
 lazy_static = "1.5.0"
-openssl-probe = "0.1.5"
 
 [features]
 default = ["curl/ssl"]

--- a/photon/Cargo.toml
+++ b/photon/Cargo.toml
@@ -23,6 +23,7 @@ rand = "0.8.5"
 bincode = "2.0.0-rc.3"
 lz4 = "1.28.0"
 lazy_static = "1.5.0"
+base64 = "0.22.1"
 
 [features]
 default = ["curl/ssl"]

--- a/photon/src/http.rs
+++ b/photon/src/http.rs
@@ -123,7 +123,7 @@ fn curl_do_request(
     curl.get_mut().reset(); // Reset collector
     curl.reset(); // Reset handle to initial state, keeping connections open
     curl.cookie_list("ALL").unwrap(); // Reset stored cookies
-    
+
     // Setup CURL context for this request
 
     curl.path_as_is(true).unwrap();

--- a/photon/src/http.rs
+++ b/photon/src/http.rs
@@ -127,8 +127,8 @@ fn curl_do_request(
     // Setup CURL context for this request
 
     curl.path_as_is(true).unwrap();
-    // Don't verify any certs
     curl.useragent(&options.user_agent).unwrap();
+    // Don't verify any certs
     curl.ssl_verify_peer(false).unwrap();
     curl.ssl_verify_host(false).unwrap();
     //curl.follow_location(true).unwrap(); // Follow redirects, TODO: make configurable, AFAIK templates can change this opt

--- a/photon/src/lib.rs
+++ b/photon/src/lib.rs
@@ -27,6 +27,7 @@ use photon_dsl::{
     dsl::{DSLStack, Value},
     DslFunction,
 };
+use rand::Rng;
 use regex::Regex;
 use rustc_hash::FxHashMap;
 
@@ -152,6 +153,20 @@ fn init_functions() -> FxHashMap<String, DslFunction> {
                 let decoded_vec = base16ct::mixed::decode_vec(inp).map_err(|_| ())?; // TODO: Don't map err, use some proper DSL error handling
                 let decoded_str = String::from_utf8_lossy(&decoded_vec);
                 Ok(Value::String(String::from(decoded_str)))
+            }),
+        ),
+    );
+    functions.insert(
+        "rand_int".into(),
+        DslFunction::new(
+            2,
+            Box::new(|stack: &mut DSLStack| {
+                let max = stack.pop_int()?;
+                let min = stack.pop_int()?;
+
+                let rand_value = rand::thread_rng().gen_range(min..max);
+
+                Ok(Value::Int(rand_value))
             }),
         ),
     );

--- a/photon/src/lib.rs
+++ b/photon/src/lib.rs
@@ -200,6 +200,7 @@ fn init_functions() -> FxHashMap<String, DslFunction> {
                 let max = stack.pop_int()?;
                 let min = stack.pop_int()?;
 
+                // [min, max) like nuclei does, exclusive range
                 let rand_value = rand::thread_rng().gen_range(min..max);
 
                 Ok(Value::Int(rand_value))
@@ -273,8 +274,8 @@ mod tests {
             &functions,
             "base64_decode('YmFzZTY0IHRlc3Qgc3RyaW5n') == 'base64 test string'"
         ));
-        // I know these are random, but 33% chance + mainly as as sanity check
+        // Random tests, shows that rand_int is exclusive
         assert!(test_expression(&functions, "rand_int(1, 3) >= 1"));
-        assert!(test_expression(&functions, "rand_int(1, 3) <= 2"));
+        assert!(test_expression(&functions, "rand_int(1, 3) < 3"));
     }
 }

--- a/photon/src/lib.rs
+++ b/photon/src/lib.rs
@@ -246,7 +246,10 @@ mod tests {
             &functions,
             "md5('test') == '098f6bcd4621d373cade4e832627b4f6'"
         ));
-        assert!(test_expression(&functions, "base64_decode('YmFzZTY0IHRlc3Qgc3RyaW5n') == 'base64 test string'"));
+        assert!(test_expression(
+            &functions,
+            "base64_decode('YmFzZTY0IHRlc3Qgc3RyaW5n') == 'base64 test string'"
+        ));
         // I know these are random, but 33% chance + mainly as as sanity check
         assert!(test_expression(&functions, "rand_int(1, 3) >= 1"));
         assert!(test_expression(&functions, "rand_int(1, 3) <= 2"));

--- a/photon/src/lib.rs
+++ b/photon/src/lib.rs
@@ -164,8 +164,15 @@ fn init_functions() -> FxHashMap<String, DslFunction> {
             Box::new(|stack: &mut DSLStack| {
                 let inp = stack.pop_string()?;
                 let decoded_vec = BASE64_STANDARD.decode(inp).map_err(|_| ())?; // TODO: Don't map err, use some proper DSL error handling
-                let decoded_str = String::from_utf8_lossy(&decoded_vec);
-                Ok(Value::String(String::from(decoded_str)))
+                let res = String::from_utf8(decoded_vec); // TODO: possibly needs to return raw bytes (not supported in DSL right now) instead of valid UTF-8
+                match res {
+                    Ok(decoded_str) => {
+                        Ok(Value::String(decoded_str))
+                    },
+                    Err(_) => {
+                        Err(())
+                    }
+                }
             }),
         ),
     );

--- a/photon/src/lib.rs
+++ b/photon/src/lib.rs
@@ -81,7 +81,7 @@ pub fn set_config(config: Config) {
 
 // Basic health check for outsiders to check if domain seems alive or not.
 // Uses similar curl settings as `http.rs` for similar behavior
-pub fn health_check(url: &str) -> bool {
+pub fn health_check(url: &str) -> Result<(), curl::Error> {
     let mut curl = Easy::new();
     curl.path_as_is(true).unwrap();
     // TODO: maybe use useragent? for now it's just curl default for health check
@@ -94,7 +94,7 @@ pub fn health_check(url: &str) -> bool {
     curl.timeout(Duration::from_secs(20)).unwrap();
     curl.url(url).unwrap();
 
-    curl.perform().is_ok()
+    curl.perform()
 }
 
 fn init_functions() -> FxHashMap<String, DslFunction> {

--- a/photon/src/lib.rs
+++ b/photon/src/lib.rs
@@ -164,8 +164,9 @@ fn init_functions() -> FxHashMap<String, DslFunction> {
             Box::new(|stack: &mut DSLStack| {
                 let inp = stack.pop_string()?;
                 let decoded_vec = BASE64_STANDARD.decode(inp).map_err(|_| ())?; // TODO: Don't map err, use some proper DSL error handling
-                let res = String::from_utf8(decoded_vec); // TODO: possibly needs to return raw bytes (not supported in DSL right now) instead of valid UTF-8
-                match res {
+
+                // TODO: possibly needs to return raw bytes (not supported in DSL right now) instead of valid UTF-8
+                match String::from_utf8(decoded_vec) {
                     Ok(decoded_str) => Ok(Value::String(decoded_str)),
                     Err(_) => Err(()),
                 }

--- a/photon/src/lib.rs
+++ b/photon/src/lib.rs
@@ -166,12 +166,8 @@ fn init_functions() -> FxHashMap<String, DslFunction> {
                 let decoded_vec = BASE64_STANDARD.decode(inp).map_err(|_| ())?; // TODO: Don't map err, use some proper DSL error handling
                 let res = String::from_utf8(decoded_vec); // TODO: possibly needs to return raw bytes (not supported in DSL right now) instead of valid UTF-8
                 match res {
-                    Ok(decoded_str) => {
-                        Ok(Value::String(decoded_str))
-                    },
-                    Err(_) => {
-                        Err(())
-                    }
+                    Ok(decoded_str) => Ok(Value::String(decoded_str)),
+                    Err(_) => Err(()),
                 }
             }),
         ),


### PR DESCRIPTION
Since we completely ignore CA certs now (no reason to deal with those during scanning) we're safe to just remove all CA-related code.
### Changes
* Use full LTO - large chunk of binary size is dynamic relocations (.rela.dyn) which is optimized (along with other things) better with full LTO. Reduces binary size from  ~3MB -> 2.5MB
* Clean up CA cert code and remove dependency since we don't need anymore.
* Add hot fix for `bake_ctx` as discussed earlier, with a TODO for a proper refactoring at a later point.
* Added missing `rand_int` function with mandatory min and max, created issue #18 for vararg functions related to it.
* Added `base64_decode`, pretty self-explanatory, currently validates utf8 since result is stored in std::String, with comment for non-unicode support in the future (base64 often used for raw binary data)
* Added `health_check` function to check if website is alive, and use it in `photon-cli`