### PR TITLE
Support single quote strings inside double quote strings and vice versa

### DIFF
--- a/photon-dsl/src/dsl.pest
+++ b/photon-dsl/src/dsl.pest
@@ -8,10 +8,12 @@ ident = @{ ("_" | "." | alpha) ~ ("_" | "." | alpha | digit)* }
 
 predefined = _{ "n" | "r" | "t" | "\\" | "0" | "\"" | "'" }
 escape     = _{ "\\" ~ predefined }
-raw_string = _{ (!("\\" | "\"" | "'") ~ ANY)+ }
-string =  { (raw_string | escape)* }
+raw_string_single = _{ ("\\'" | !"'" ~ ANY)+ }
+raw_string_double = _{ ("\\\"" | !"\"" ~ ANY)+ }
+single_string =  { (escape | raw_string_single)* }
+double_string =  { (escape | raw_string_double)* }
 // Compound atomic so pest doesn't eat the first and last whitespace inside a string
-_string     = ${ ("'" ~ string ~ "'") | ("\"" ~ string ~ "\"") }
+_string     = ${ ("'" ~ single_string ~ "'") | ("\"" ~ double_string ~ "\"") }
 eoi        = _{ !ANY }
 
 init       = _{ SOI ~ primary ~ eoi }

--- a/photon-dsl/src/parser.rs
+++ b/photon-dsl/src/parser.rs
@@ -98,7 +98,9 @@ fn unescape(s: &str) -> Result<String, ()> {
 fn parse_primary(primary: Pair<'_, Rule>) -> Expr {
     match primary.as_rule() {
         Rule::expr | Rule::clause | Rule::_string => parse_expr(primary.into_inner()),
-        Rule::single_string | Rule::double_string => Expr::Constant(Value::String(unescape(primary.as_str()).unwrap())),
+        Rule::single_string | Rule::double_string => {
+            Expr::Constant(Value::String(unescape(primary.as_str()).unwrap()))
+        }
         Rule::boolean => Expr::Constant(Value::Boolean(primary.as_str().parse::<bool>().unwrap())),
         Rule::variable => Expr::Variable(primary.as_str().to_string()),
         Rule::digit => {

--- a/photon-dsl/src/parser.rs
+++ b/photon-dsl/src/parser.rs
@@ -98,7 +98,7 @@ fn unescape(s: &str) -> Result<String, ()> {
 fn parse_primary(primary: Pair<'_, Rule>) -> Expr {
     match primary.as_rule() {
         Rule::expr | Rule::clause | Rule::_string => parse_expr(primary.into_inner()),
-        Rule::string => Expr::Constant(Value::String(unescape(primary.as_str()).unwrap())),
+        Rule::single_string | Rule::double_string => Expr::Constant(Value::String(unescape(primary.as_str()).unwrap())),
         Rule::boolean => Expr::Constant(Value::Boolean(primary.as_str().parse::<bool>().unwrap())),
         Rule::variable => Expr::Variable(primary.as_str().to_string()),
         Rule::digit => {


### PR DESCRIPTION
Fixes some minor edge cases where we have strings like
`'some "string"'`
New behavior so that when a single quotes string starts, it only ends when another un-escaped single quote appears, and same for double quotes