### PR TITLE
Use CStr during CURL FFI

### DIFF
--- a/photon/src/http.rs
+++ b/photon/src/http.rs
@@ -1,6 +1,7 @@
 use core::str;
 use std::{
     collections::HashSet,
+    ffi::CStr,
     sync::OnceLock,
     time::{Duration, Instant},
 };
@@ -160,16 +161,32 @@ fn curl_do_request(
         // HTTP Methods outside of GET aren't implemented for CURL's Easy wrapper
         // So we interact with the raw curl handle manually, and set the request type to "custom"
         Method::DELETE => unsafe {
-            curl_sys::curl_easy_setopt(curl.raw(), CURLOPT_CUSTOMREQUEST, c"DELETE");
+            curl_sys::curl_easy_setopt(
+                curl.raw(),
+                CURLOPT_CUSTOMREQUEST,
+                CStr::from_bytes_with_nul(b"DELETE\0").unwrap(),
+            );
         },
         Method::HEAD => unsafe {
-            curl_sys::curl_easy_setopt(curl.raw(), CURLOPT_CUSTOMREQUEST, c"HEAD");
+            curl_sys::curl_easy_setopt(
+                curl.raw(),
+                CURLOPT_CUSTOMREQUEST,
+                CStr::from_bytes_with_nul(b"HEAD\0").unwrap(),
+            );
         },
         Method::OPTIONS => unsafe {
-            curl_sys::curl_easy_setopt(curl.raw(), CURLOPT_CUSTOMREQUEST, c"OPTIONS");
+            curl_sys::curl_easy_setopt(
+                curl.raw(),
+                CURLOPT_CUSTOMREQUEST,
+                CStr::from_bytes_with_nul(b"OPTIONS\0").unwrap(),
+            );
         },
         Method::PATCH => unsafe {
-            curl_sys::curl_easy_setopt(curl.raw(), CURLOPT_CUSTOMREQUEST, c"PATCH");
+            curl_sys::curl_easy_setopt(
+                curl.raw(),
+                CURLOPT_CUSTOMREQUEST,
+                CStr::from_bytes_with_nul(b"PATCH\0").unwrap(),
+            );
         },
     }
 

--- a/photon/src/http.rs
+++ b/photon/src/http.rs
@@ -160,16 +160,16 @@ fn curl_do_request(
         // HTTP Methods outside of GET aren't implemented for CURL's Easy wrapper
         // So we interact with the raw curl handle manually, and set the request type to "custom"
         Method::DELETE => unsafe {
-            curl_sys::curl_easy_setopt(curl.raw(), CURLOPT_CUSTOMREQUEST, "DELETE");
+            curl_sys::curl_easy_setopt(curl.raw(), CURLOPT_CUSTOMREQUEST, c"DELETE");
         },
         Method::HEAD => unsafe {
-            curl_sys::curl_easy_setopt(curl.raw(), CURLOPT_CUSTOMREQUEST, "HEAD");
+            curl_sys::curl_easy_setopt(curl.raw(), CURLOPT_CUSTOMREQUEST, c"HEAD");
         },
         Method::OPTIONS => unsafe {
-            curl_sys::curl_easy_setopt(curl.raw(), CURLOPT_CUSTOMREQUEST, "OPTIONS");
+            curl_sys::curl_easy_setopt(curl.raw(), CURLOPT_CUSTOMREQUEST, c"OPTIONS");
         },
         Method::PATCH => unsafe {
-            curl_sys::curl_easy_setopt(curl.raw(), CURLOPT_CUSTOMREQUEST, "PATCH");
+            curl_sys::curl_easy_setopt(curl.raw(), CURLOPT_CUSTOMREQUEST, c"PATCH");
         },
     }
 


### PR DESCRIPTION
HEAD, DELETE, PATCH and OPTIONS requests weren't working, since it just sent a whole bunch of random constants concatenated together since we were passing a Rust string instead of a CStr