### PR TITLE
Exact pest dependency

### DIFF
--- a/photon-dsl/Cargo.toml
+++ b/photon-dsl/Cargo.toml
@@ -10,6 +10,6 @@ rust-version = "1.75"
 [dependencies]
 regex = "1.10.6"
 rustc-hash = "2.0.0"
-pest = "2.8.0"
+pest = "=2.8.0"
 pest_derive = "2.7.11"
 lazy_static = "1.5.0"


### PR DESCRIPTION
 Otherwise cargo will attempt to pull in version `2.8.1` which has a minimum compiler version of 1.80, which is higher than our minimum compiler version (1.75)