### PR TITLE
Fix word expression matching

### DIFF
--- a/photon-cli/src/main.rs
+++ b/photon-cli/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
 
     let base_url = &args.url;
 
-    if let Err(err) = health_check(&base_url, Duration::from_secs(15)) {
+    if let Err(err) = health_check(base_url, Duration::from_secs(15)) {
         println!("Healthcheck failed: {}", err.description());
         return;
     }

--- a/photon-dsl/src/dsl.rs
+++ b/photon-dsl/src/dsl.rs
@@ -59,8 +59,8 @@ pub enum Value {
     // TODO: Add Array support
 }
 
-impl Value {
-    pub fn to_string(&self) -> String {
+impl ToString for Value {
+    fn to_string(&self) -> String {
         match &self {
             Value::String(string) => string.clone(),
             Value::Int(i) => format!("{i}"),

--- a/photon/src/http.rs
+++ b/photon/src/http.rs
@@ -60,7 +60,7 @@ fn bake_ctx(inp: &str, ctx: &Context, photon_ctx: &PhotonContext) -> Option<Stri
         let mut updated = 0;
         for mat in matches.iter() {
             let compiled =
-                compile_expression_validated(&mat.get(1).unwrap().as_str(), &photon_ctx.functions);
+                compile_expression_validated(mat.get(1).unwrap().as_str(), &photon_ctx.functions);
             if let Ok(expr) = compiled {
                 let res = expr.execute(&ctx, &photon_ctx.functions);
                 if let Ok(Value::String(ret)) = res {

--- a/photon/src/lib.rs
+++ b/photon/src/lib.rs
@@ -105,7 +105,7 @@ fn init_functions() -> FxHashMap<String, DslFunction> {
         DslFunction::new(
             1,
             Box::new(|stack: &mut DSLStack| {
-                let inp = stack.pop_string()?;
+                let inp = stack.pop()?.to_string();
                 let hash = base16ct::lower::encode_string(&Md5::digest(inp));
                 Ok(Value::String(hash))
             }),


### PR DESCRIPTION
Some general cleanup as well.
This fixes some false positives, e.g. https://github.com/projectdiscovery/nuclei-templates/blob/99a99ed3d15429c8dfe4c70459e322cbf8ffe4c4/http/cves/2015/CVE-2015-7297.yaml
where the expression accidentally compiled into `999999999` instead of the md5 hash of said number