### PR TITLE
Implement attack mode and payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -647,6 +647,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "jni"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +912,7 @@ dependencies = [
  "curl",
  "curl-sys",
  "httparse",
+ "itertools 0.14.0",
  "lazy_static",
  "lz4",
  "md-5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "murmur3"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +922,7 @@ dependencies = [
  "lazy_static",
  "lz4",
  "md-5",
+ "murmur3",
  "photon_dsl",
  "rand",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ resolver = "2"
 opt-level = 1
 
 [profile.release]
+# Full LTO makes binary substantially smaller, due to some linking stuff
 lto = true
 strip = true
 panic = "abort"

--- a/photon-dsl/src/dsl.rs
+++ b/photon-dsl/src/dsl.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use regex::Regex;
 use rustc_hash::FxHashMap;
 
@@ -59,14 +61,18 @@ pub enum Value {
     // TODO: Add Array support
 }
 
-impl ToString for Value {
-    fn to_string(&self) -> String {
-        match &self {
-            Value::String(string) => string.clone(),
-            Value::Int(i) => format!("{i}"),
-            Value::Short(i) => format!("{i}"),
-            Value::Boolean(b) => format!("{b}"),
-        }
+impl Display for Value {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match &self {
+                Value::String(string) => string.clone(),
+                Value::Int(i) => format!("{i}"),
+                Value::Short(i) => format!("{i}"),
+                Value::Boolean(b) => format!("{b}"),
+            }
+        )
     }
 }
 
@@ -410,6 +416,10 @@ impl DSLStack {
         self.inner.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub fn push(&mut self, val: Value) {
         self.inner.push(val);
     }
@@ -487,7 +497,7 @@ fn handle_op(op: OPCode, stack: &mut DSLStack) -> Result<(), ()> {
                 }
                 Value::String(b) => {
                     let a = stack.pop_string()?;
-                    stack.push(Value::String(format!("{}{}", a, b)));
+                    stack.push(Value::String(format!("{a}{b}")));
                     Ok(())
                 }
                 _ => Err(()),

--- a/photon-dsl/src/dsl.rs
+++ b/photon-dsl/src/dsl.rs
@@ -63,16 +63,12 @@ pub enum Value {
 
 impl Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match &self {
-                Value::String(string) => string.clone(),
-                Value::Int(i) => format!("{i}"),
-                Value::Short(i) => format!("{i}"),
-                Value::Boolean(b) => format!("{b}"),
-            }
-        )
+        match &self {
+            Value::String(string) => write!(f, "{string}"),
+            Value::Int(i) => write!(f, "{i}"),
+            Value::Short(i) => write!(f, "{i}"),
+            Value::Boolean(b) => write!(f, "{b}"),
+        }
     }
 }
 

--- a/photon/Cargo.toml
+++ b/photon/Cargo.toml
@@ -25,6 +25,7 @@ lz4 = "1.28.0"
 lazy_static = "1.5.0"
 base64 = "0.22.1"
 itertools = "0.14.0"
+murmur3 = "0.5.2"
 
 [features]
 default = ["curl/ssl"]

--- a/photon/Cargo.toml
+++ b/photon/Cargo.toml
@@ -24,6 +24,7 @@ bincode = "2.0.0-rc.3"
 lz4 = "1.28.0"
 lazy_static = "1.5.0"
 base64 = "0.22.1"
+itertools = "0.14.0"
 
 [features]
 default = ["curl/ssl"]

--- a/photon/src/cache.rs
+++ b/photon/src/cache.rs
@@ -83,7 +83,10 @@ impl Cache {
     }
 
     pub fn can_cache(&self, key: &CacheKey) -> bool {
-        self.current_tokens.contains_key(key) || true
+        //self.current_tokens.contains_key(key)
+
+        // XXX: Always return true for now, while the caching implementation caches all requests
+        true
     }
 }
 

--- a/photon/src/cache.rs
+++ b/photon/src/cache.rs
@@ -31,6 +31,7 @@ impl Cache {
     }
 
     fn decrease_token(&mut self, key: &CacheKey) {
+        return;
         let tokens_left = self.current_tokens.get_mut(key).unwrap();
         if *tokens_left == 1 {
             // Final token, we know this cache key will never be accessed again until we reset
@@ -81,7 +82,7 @@ impl Cache {
     }
 
     pub fn can_cache(&self, key: &CacheKey) -> bool {
-        self.current_tokens.contains_key(key)
+        self.current_tokens.contains_key(key) || true
     }
 }
 

--- a/photon/src/cache.rs
+++ b/photon/src/cache.rs
@@ -31,7 +31,6 @@ impl Cache {
     }
 
     fn decrease_token(&mut self, key: &CacheKey) {
-        return;
         let tokens_left = self.current_tokens.get_mut(key).unwrap();
         if *tokens_left == 1 {
             // Final token, we know this cache key will never be accessed again until we reset
@@ -53,7 +52,9 @@ impl Cache {
 
     pub fn get(&mut self, key: &CacheKey) -> Option<HttpResponse> {
         let ret = self.inner.get(key).unwrap().clone();
-        self.decrease_token(key);
+        // XXX: Tokens are currently used to determine if its likely a request
+        // repeated across multiple templates, thus we don't decrease currently
+        //self.decrease_token(key);
         if let Some(data) = ret {
             // Unwraps below should be 100% safe, since both bincode and compressed data are created by `store` function below.
             let decompressed = block::decompress(&data, None).unwrap();

--- a/photon/src/http.rs
+++ b/photon/src/http.rs
@@ -282,10 +282,9 @@ impl HttpReq {
         let mut req = httparse::Request::new(&mut headers);
         let parsed = req.parse(raw_data.as_bytes());
         if let Err(err) = parsed {
-            verbose!(
+            debug!(
                 "Error parsing raw request: {} - request: '{}'",
-                err,
-                raw_data
+                err, raw_data
             );
             return None;
         }
@@ -356,7 +355,7 @@ impl HttpReq {
         let path = path.trim().to_string();
 
         // Skip caching below if we know the request is only happening once
-        let key = CacheKey(self.method, self.headers.clone(), self.path.clone());
+        let key = CacheKey(self.method, self.headers.clone(), path.clone());
         if !cache.can_cache(&key) {
             let res = self.internal_request(&path, options, curl, req_counter);
             if let Some(resp) = res {

--- a/photon/src/http.rs
+++ b/photon/src/http.rs
@@ -355,6 +355,7 @@ impl HttpReq {
         let path = path.trim().to_string();
 
         // Skip caching below if we know the request is only happening once
+        // XXX: Currently caches all requests, regardless of if their responses are re-used
         let key = CacheKey(self.method, self.headers.clone(), path.clone());
         if !cache.can_cache(&key) {
             let res = self.internal_request(&path, options, curl, req_counter);

--- a/photon/src/http.rs
+++ b/photon/src/http.rs
@@ -32,7 +32,7 @@ pub fn get_bracket_pattern() -> &'static Regex {
 
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct HttpResponse {
-    pub body: String,
+    pub body: Vec<u8>,
     pub headers: Vec<(String, String)>,
     pub status_code: u32,
     pub duration: f32,
@@ -211,7 +211,6 @@ fn curl_do_request(
     let duration = stopwatch.elapsed().as_secs_f32();
 
     let contents = curl.get_ref();
-    let body = String::from_utf8_lossy(&contents.0);
     let headers = parse_headers(&contents.1)?;
     debug!(
         "Got status {} for URL '{}', took {:.2}s",
@@ -219,10 +218,10 @@ fn curl_do_request(
         path,
         duration
     );
-    debug!("Body len: {}", body.len());
+    debug!("Body len: {}", contents.0.len());
 
     let resp = HttpResponse {
-        body: body.to_string(),
+        body: contents.0.clone(),
         status_code: curl.response_code().unwrap(),
         duration,
         headers,

--- a/photon/src/http.rs
+++ b/photon/src/http.rs
@@ -2,6 +2,7 @@ use core::str;
 use std::{
     collections::HashSet,
     ffi::CStr,
+    mem,
     sync::OnceLock,
     time::{Duration, Instant},
 };
@@ -210,18 +211,19 @@ fn curl_do_request(
 
     let duration = stopwatch.elapsed().as_secs_f32();
 
-    let contents = curl.get_ref();
-    let headers = parse_headers(&contents.1)?;
     debug!(
         "Got status {} for URL '{}', took {:.2}s",
         curl.response_code().unwrap(),
         path,
         duration
     );
+
+    let contents = curl.get_mut();
+    let headers = parse_headers(&contents.1)?;
     debug!("Body len: {}", contents.0.len());
 
     let resp = HttpResponse {
-        body: contents.0.clone(),
+        body: mem::take(&mut contents.0),
         status_code: curl.response_code().unwrap(),
         duration,
         headers,

--- a/photon/src/http.rs
+++ b/photon/src/http.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use bincode::{Decode, Encode};
-use curl::easy::{Easy2, List};
+use curl::easy::{Easy2, Handler, List, WriteError};
 use curl_sys::CURLOPT_CUSTOMREQUEST;
 use httparse::Status;
 use photon_dsl::{
@@ -20,7 +20,7 @@ use regex::Regex;
 use crate::{
     cache::{Cache, CacheKey},
     get_config,
-    template::{Collector, Context, Method},
+    template::{Context, Method},
     template_executor::ExecutionOptions,
     PhotonContext,
 };
@@ -111,9 +111,34 @@ fn parse_headers(contents: &[u8]) -> Option<Vec<(String, String)>> {
         })
         .collect()
 }
+pub struct Collector(pub Vec<u8>, pub Vec<u8>);
+
+impl Handler for Collector {
+    fn write(&mut self, data: &[u8]) -> Result<usize, WriteError> {
+        self.0.extend_from_slice(data);
+        Ok(data.len())
+    }
+
+    fn header(&mut self, data: &[u8]) -> bool {
+        // Make sure we're appending headers only, curl also gives us the HTTP response code header as well for some reason
+        if data.contains(&b':') {
+            self.1.extend_from_slice(data);
+        }
+        true
+    }
+}
+
+impl Collector {
+    pub fn reset(&mut self) {
+        self.0.clear();
+        self.1.clear();
+    }
+}
+
+pub(crate) type CurlHandle = Easy2<Collector>;
 
 fn curl_do_request(
-    curl: &mut Easy2<Collector>,
+    curl: &mut CurlHandle,
     options: &ExecutionOptions,
     req: &HttpReq,
     path: &str,
@@ -246,7 +271,7 @@ impl HttpReq {
         &self,
         path: &str,
         options: &ExecutionOptions,
-        curl: &mut Easy2<Collector>,
+        curl: &mut CurlHandle,
         req_counter: &mut u32,
     ) -> Option<HttpResponse> {
         let resp = curl_do_request(curl, options, self, path, self.body.as_bytes());
@@ -263,7 +288,7 @@ impl HttpReq {
         ctx: &Context,
         photon_ctx: &PhotonContext,
         options: &ExecutionOptions,
-        curl: &mut Easy2<Collector>,
+        curl: &mut CurlHandle,
         req_counter: &mut u32,
     ) -> Option<HttpResponse> {
         let mut raw_data = self.bake_raw(ctx, photon_ctx)?;
@@ -337,7 +362,7 @@ impl HttpReq {
         &self,
         base_url: &str,
         options: &ExecutionOptions,
-        curl: &mut Easy2<Collector>,
+        curl: &mut CurlHandle,
         ctx: &Context,
         photon_ctx: &PhotonContext,
         req_counter: &mut u32,

--- a/photon/src/lib.rs
+++ b/photon/src/lib.rs
@@ -24,6 +24,7 @@ use std::{sync::Mutex, time::Duration};
 
 use base64::{prelude::BASE64_STANDARD, Engine};
 use curl::easy::Easy;
+use itertools::Itertools;
 use md5::{Digest, Md5};
 use photon_dsl::{
     dsl::{DSLStack, Value},
@@ -193,6 +194,42 @@ fn init_functions() -> FxHashMap<String, DslFunction> {
         ),
     );
     functions.insert(
+        "base64".into(),
+        DslFunction::new(
+            1,
+            Box::new(|stack: &mut DSLStack| {
+                let inp = stack.pop_string()?;
+                Ok(Value::String(BASE64_STANDARD.encode(inp)))
+            }),
+        ),
+    );
+    functions.insert(
+        "base64_py".into(),
+        DslFunction::new(
+            1,
+            Box::new(|stack: &mut DSLStack| {
+                let inp = stack.pop_string()?;
+                let encoded = BASE64_STANDARD.encode(inp);
+                let mut pythonic = String::with_capacity(encoded.len() + 10); // Slightly larger string, to account for the added spaces in most cases
+
+                // According to nuclei, Python's base64 encoder creates base64 with lines of max length 76
+                // Although I haven't been able to verify that, might be old python behavior?
+                for chunk in &encoded.chars().chunks(76) {
+                    let mut len = 0;
+                    for chr in chunk {
+                        pythonic.push(chr);
+                        len += 1;
+                    }
+                    if len == 76 {
+                        pythonic.push('\n');
+                    }
+                }
+
+                Ok(Value::String(pythonic))
+            }),
+        ),
+    );
+    functions.insert(
         "rand_int".into(),
         DslFunction::new(
             2,
@@ -273,6 +310,20 @@ mod tests {
         assert!(test_expression(
             &functions,
             "base64_decode('YmFzZTY0IHRlc3Qgc3RyaW5n') == 'base64 test string'"
+        ));
+        assert!(test_expression(
+            &functions,
+            "base64('base64 test string') == 'YmFzZTY0IHRlc3Qgc3RyaW5n'"
+        ));
+        // Line shorter than 76 letters case
+        assert!(test_expression(
+            &functions,
+            "base64_py('base64 test string') == 'YmFzZTY0IHRlc3Qgc3RyaW5n'"
+        ));
+        // Line longer than 76 letters case
+        assert!(test_expression(
+            &functions,
+            "base64_py('base64 test string base64 test string base64 test string base64 test string base64 test string') == 'YmFzZTY0IHRlc3Qgc3RyaW5nIGJhc2U2NCB0ZXN0IHN0cmluZyBiYXNlNjQgdGVzdCBzdHJpbmcg\nYmFzZTY0IHRlc3Qgc3RyaW5nIGJhc2U2NCB0ZXN0IHN0cmluZw=='"
         ));
         // Random tests, shows that rand_int is exclusive
         assert!(test_expression(&functions, "rand_int(1, 3) >= 1"));

--- a/photon/src/lib.rs
+++ b/photon/src/lib.rs
@@ -16,6 +16,7 @@ macro_rules! verbose {
 
 mod cache;
 mod http;
+mod matcher;
 pub mod template;
 pub mod template_executor;
 pub mod template_loader;

--- a/photon/src/lib.rs
+++ b/photon/src/lib.rs
@@ -20,12 +20,13 @@ pub mod template;
 pub mod template_executor;
 pub mod template_loader;
 
-use std::{sync::Mutex, time::Duration};
+use std::{io::Cursor, sync::Mutex, time::Duration};
 
 use base64::{prelude::BASE64_STANDARD, Engine};
 use curl::easy::Easy;
 use itertools::Itertools;
 use md5::{Digest, Md5};
+use murmur3::murmur3_32;
 use photon_dsl::{
     dsl::{DSLStack, Value},
     DslFunction,
@@ -226,6 +227,17 @@ fn init_functions() -> FxHashMap<String, DslFunction> {
                 }
 
                 Ok(Value::String(pythonic))
+            }),
+        ),
+    );
+    functions.insert(
+        "mmh3".into(), // MurMurHash3
+        DslFunction::new(
+            1,
+            Box::new(|stack: &mut DSLStack| {
+                let inp = stack.pop_string()?;
+                let hash_result = murmur3_32(&mut Cursor::new(inp), 0).map_err(|_| ())?;
+                Ok(Value::Int(hash_result as i64))
             }),
         ),
     );

--- a/photon/src/matcher.rs
+++ b/photon/src/matcher.rs
@@ -1,0 +1,305 @@
+use photon_dsl::dsl::{CompiledExpression, Value};
+
+use crate::{
+    cache::RegexCache,
+    get_config,
+    http::{bake_ctx, get_bracket_pattern, HttpResponse},
+    template::{Condition, Context},
+    PhotonContext,
+};
+
+#[derive(Debug, Clone)]
+pub enum MatcherType {
+    Word(Vec<String>),
+    DSL(Vec<CompiledExpression>),
+    Regex(Vec<u32>), // indicies into RegexCache
+    Status(Vec<u32>),
+}
+
+#[derive(Debug, Clone)]
+pub enum ExtractorType {
+    Matcher(MatcherType),
+    Kval(Vec<String>),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ExtractorPart {
+    HeaderCookie, // Either Header or Cookie, with Header having priority
+    Header,
+    Cookie,
+    // Response Parts
+    Body,
+    Raw,
+    All,
+    Response, // Seems to be an alias for All, https://github.com/projectdiscovery/nuclei/blob/dev/SYNTAX-REFERENCE.md#httprequest
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ResponsePart {
+    Body,
+    Raw,
+    Header,
+    All,
+    Response, // Seems to be an alias for All, https://github.com/projectdiscovery/nuclei/blob/dev/SYNTAX-REFERENCE.md#httprequest
+}
+
+#[derive(Debug, Clone)]
+pub struct Matcher {
+    pub r#type: MatcherType,
+    pub name: Option<String>,
+    pub negative: bool,
+    pub group: Option<i64>, // Regex group number, None represents entire regex match
+    pub internal: bool,     // Used for workflows, matches, but does not print
+    pub part: ResponsePart,
+    pub condition: Condition,
+}
+
+#[derive(Debug, Clone)]
+pub struct Extractor {
+    pub r#type: ExtractorType,
+    pub name: Option<String>,
+    pub group: Option<i64>, // Regex group number, None represents entire regex match
+    pub internal: bool,     // Used for workflows, matches, but does not print
+    pub part: ExtractorPart,
+}
+
+fn extractor_part_to_string(data: &HttpResponse, part: ExtractorPart) -> String {
+    match part {
+        // Map 1:1 Extractor -> Response parts
+        ExtractorPart::All => response_to_string(data, ResponsePart::All),
+        ExtractorPart::Response => response_to_string(data, ResponsePart::Response),
+        ExtractorPart::Body => response_to_string(data, ResponsePart::Body),
+        ExtractorPart::Raw => response_to_string(data, ResponsePart::Raw),
+        // Cookies are in Headers, so HeaderCookie maps to Headers string
+        ExtractorPart::Header | ExtractorPart::HeaderCookie => {
+            response_to_string(data, ResponsePart::Header)
+        }
+
+        // Concatenated all cookie headers into a single string
+        ExtractorPart::Cookie => data
+            .headers
+            .iter()
+            .filter(|(key, _)| key.to_lowercase() == "set-cookie")
+            .map(|(_, value)| format!("{value}\n"))
+            .collect::<Vec<String>>()
+            .concat(),
+    }
+}
+
+// Get (Key, Value) pairs from cookies
+fn extractor_get_cookies(data: &HttpResponse) -> Vec<(String, String)> {
+    data.headers
+        .iter()
+        .filter(|(key, _)| key.to_lowercase() == "set-cookie")
+        .filter_map(|(_, value)| {
+            let cookie_kv = value.split(';').next().unwrap().split_once('=');
+            if let Some((key, value)) = cookie_kv {
+                // https://docs.projectdiscovery.io/templates/reference/extractors#kval-extractor
+                // Nuclei kval extractors don't support dashes, so we modify the key to conform to their spec
+                Some((String::from(key).replace('-', "_"), String::from(value)))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<(String, String)>>()
+}
+
+fn response_to_string(data: &HttpResponse, part: ResponsePart) -> String {
+    match part {
+        ResponsePart::All | ResponsePart::Response => {
+            // TODO: Actually return proper All, now easier using CURL
+            let mut parts = vec![];
+            data.headers
+                .iter()
+                .for_each(|(k, v)| parts.push(format!("{k}: {v}\n")));
+            parts.push(String::from_utf8_lossy(&data.body).into());
+            parts.concat()
+        }
+        ResponsePart::Body => String::from_utf8_lossy(&data.body).into(),
+        ResponsePart::Header => data
+            .headers
+            .iter()
+            .map(|(k, v)| format!("{k}: {v}\n"))
+            .collect::<Vec<String>>()
+            .concat(),
+        ResponsePart::Raw => {
+            // TODO: Actually return Raw
+            let mut parts = vec![];
+            data.headers
+                .iter()
+                .for_each(|(k, v)| parts.push(format!("{k}: {v}\n")));
+            parts.push(String::from_utf8_lossy(&data.body).into());
+            parts.concat()
+        }
+    }
+}
+
+fn contains_with_dsl(
+    haystack: &str,
+    needle: &str,
+    ctx: &Context,
+    photon_ctx: &PhotonContext,
+) -> bool {
+    if needle.contains("{{") && get_bracket_pattern().is_match(needle) {
+        if let Some(baked) = bake_ctx(needle, ctx, photon_ctx) {
+            haystack.contains(&baked)
+        } else {
+            false
+        }
+    } else {
+        haystack.contains(needle)
+    }
+}
+
+impl Matcher {
+    pub fn matches(
+        &self,
+        data: &HttpResponse,
+        regex_cache: &RegexCache,
+        context: &Context,
+        photon_ctx: &PhotonContext,
+    ) -> bool {
+        if matches!(self.r#type, MatcherType::Status(_)) {
+            return self.matches_status(data.status_code);
+        }
+
+        let data = response_to_string(data, self.part);
+        match &self.r#type {
+            MatcherType::DSL(dsls) => {
+                if self.condition == Condition::OR {
+                    dsls.iter().any(|expr| {
+                        let res = expr.execute(&context, &photon_ctx.functions);
+                        matches!(res, Ok(Value::Boolean(true)))
+                    })
+                } else {
+                    dsls.iter().all(|expr| {
+                        let res = expr.execute(&context, &photon_ctx.functions);
+                        matches!(res, Ok(Value::Boolean(true)))
+                    })
+                }
+            }
+            MatcherType::Regex(regexes) => {
+                if self.condition == Condition::OR {
+                    regexes
+                        .iter()
+                        .any(|pattern| regex_cache.matches(*pattern, &data))
+                } else {
+                    regexes
+                        .iter()
+                        .all(|pattern| regex_cache.matches(*pattern, &data))
+                }
+            }
+            MatcherType::Word(words) => {
+                if self.condition == Condition::OR {
+                    words
+                        .iter()
+                        .any(|needle| contains_with_dsl(&data, needle, context, photon_ctx))
+                } else {
+                    words
+                        .iter()
+                        .all(|needle| contains_with_dsl(&data, needle, context, photon_ctx))
+                }
+            }
+            MatcherType::Status(_) => false,
+        }
+    }
+
+    fn matches_status(&self, status: u32) -> bool {
+        match &self.r#type {
+            MatcherType::Status(statuses) => statuses.contains(&status),
+            _ => unreachable!("Cannot match status when type != MatcherType::Status"),
+        }
+    }
+}
+
+impl Extractor {
+    // TODO: Allow multiple returns, with matchers being ran with all permutations
+    // of all possible extracted values? That's the logic according to testing with Nuclei
+    // where the matcher is ran like this pseudo logic:
+    // values.iter().any(|val| {
+    //    context.set(name, val)
+    //    matcher.matches(context)
+    //})
+    // if either matches, both values are added into the match
+    pub fn extract(
+        &self,
+        data: &HttpResponse,
+        regex_cache: &RegexCache,
+        context: &Context,
+        photon_ctx: &PhotonContext,
+    ) -> Option<Value> {
+        match &self.r#type {
+            ExtractorType::Matcher(matcher) => {
+                if let MatcherType::Status(_) = matcher {
+                    return self.matches_status(data.status_code);
+                }
+
+                let data = extractor_part_to_string(data, self.part);
+                match &matcher {
+                    MatcherType::DSL(dsls) => dsls
+                        .iter()
+                        .filter_map(|expr| expr.execute(&context, &photon_ctx.functions).ok())
+                        .next(),
+                    MatcherType::Regex(regexes) => regexes
+                        .iter()
+                        .filter_map(|pattern| {
+                            regex_cache.match_group(
+                                *pattern,
+                                &data,
+                                self.group.unwrap_or(0) as usize,
+                            )
+                        })
+                        .next()
+                        .map(Value::String),
+                    MatcherType::Word(_) => {
+                        debug!("Extractor does not support Word matching");
+                        None
+                    }
+                    MatcherType::Status(_) => None,
+                }
+            }
+            ExtractorType::Kval(fields) => {
+                let cookies = extractor_get_cookies(data);
+                match self.part {
+                    ExtractorPart::Cookie | ExtractorPart::Header => {
+                        let kv = match self.part {
+                            ExtractorPart::Cookie => &cookies,
+                            ExtractorPart::Header => &data.headers,
+                            _ => unreachable!(),
+                        };
+                        for field in fields {
+                            if let Some((_, value)) = kv
+                                .iter()
+                                .find(|(k, _)| k.to_lowercase() == field.to_lowercase())
+                            {
+                                return Some(Value::String(value.clone()));
+                            }
+                        }
+                    }
+                    ExtractorPart::HeaderCookie => {
+                        for field in fields {
+                            for kv in [&data.headers, &cookies] {
+                                if let Some((_, value)) = kv
+                                    .iter()
+                                    .find(|(k, _)| k.to_lowercase() == field.to_lowercase())
+                                {
+                                    return Some(Value::String(value.clone()));
+                                }
+                            }
+                        }
+                    }
+                    _ => return None,
+                }
+                None
+            }
+        }
+    }
+
+    fn matches_status(&self, status: u32) -> Option<Value> {
+        match &self.r#type {
+            // TODO: Maybe this should be different/Not implemented for Extractor
+            ExtractorType::Matcher(MatcherType::Status(_)) => Some(Value::Int(status as i64)),
+            _ => unreachable!("Cannot match status when type != MatcherType::Status"),
+        }
+    }
+}

--- a/photon/src/template.rs
+++ b/photon/src/template.rs
@@ -552,7 +552,7 @@ impl HttpRequest {
             // Negative XOR matches
             if matcher.negative ^ matcher.matches(&resp, regex_cache, &ctx, photon_ctx) {
                 matches.push(MatchResult {
-                    name: matcher.name.clone().unwrap_or("".to_string()),
+                    name: matcher.name.clone().unwrap_or(String::new()),
                     internal: matcher.internal,
                 });
             }

--- a/photon/src/template.rs
+++ b/photon/src/template.rs
@@ -108,10 +108,19 @@ pub struct Extractor {
     pub part: ExtractorPart,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum AttackMode {
+    Batteringram, // Default
+    Clusterbomb,
+    Pitchfork,
+}
+
 #[derive(Debug, Clone)]
 pub struct HttpRequest {
     pub extractors: Vec<Extractor>,
     pub matchers: Vec<Matcher>,
+    pub payloads: FxHashMap<String, Vec<Value>>,
+    pub attack_mode: AttackMode,
     pub matchers_condition: Condition,
     pub path: Vec<HttpReq>,
 }

--- a/photon/src/template.rs
+++ b/photon/src/template.rs
@@ -494,9 +494,7 @@ impl<'a> Iterator for AttackIterator<'a> {
             return None;
         }
 
-        self.idx += 1;
-
-        if self.is_noop {
+        let ret = if self.is_noop {
             Some(vec![])
         } else {
             // TODO: Handle Clusterbomb differently later (all possible combinations of all parameters)
@@ -508,7 +506,11 @@ impl<'a> Iterator for AttackIterator<'a> {
             }
 
             Some(ret)
-        }
+        };
+
+        self.idx += 1;
+
+        ret
     }
 }
 

--- a/photon/src/template.rs
+++ b/photon/src/template.rs
@@ -579,7 +579,6 @@ impl HttpRequest {
         // TODO: Might add an upper limit to amount of requests to send, don't want a single template doing hundreds of requests!
 
         let attack_iter = AttackIterator::new(&self.payloads, self.attack_mode);
-        let mut num_reqs = 0;
         for attack_values in attack_iter {
             for (key, value) in attack_values {
                 // TODO: for Value::String values, put them through bake_ctx, since some templates contain DSL things in payloads
@@ -599,7 +598,6 @@ impl HttpRequest {
                     cache,
                 );
                 if let Some(resp) = maybe_resp {
-                    num_reqs += 1;
                     self.handle_response(
                         resp,
                         &mut matches,

--- a/photon/src/template.rs
+++ b/photon/src/template.rs
@@ -289,7 +289,7 @@ fn contains_with_dsl(
 ) -> bool {
     if needle.contains("{{") && get_bracket_pattern().is_match(needle) {
         if let Some(baked) = bake_ctx(needle, ctx, photon_ctx) {
-            haystack.contains(&baked.to_string())
+            haystack.contains(&baked)
         } else {
             false
         }

--- a/photon/src/template.rs
+++ b/photon/src/template.rs
@@ -587,9 +587,10 @@ impl HttpRequest {
         // TODO: add upper limit to amount of requests to send, don't want a single template doing hundreds of requests!
 
         let attack_iter = AttackIterator::new(&self.payloads, self.attack_mode);
-
+        let mut num_reqs = 0;
         for attack_values in attack_iter {
             for (key, value) in attack_values {
+                // TODO: for Value::String values, put them through bake_ctx, since some templates contain DSL things in payloads
                 ctx.insert(&key, value);
             }
 
@@ -606,6 +607,7 @@ impl HttpRequest {
                     cache,
                 );
                 if let Some(resp) = maybe_resp {
+                    num_reqs += 1;
                     self.handle_response(
                         resp,
                         &mut matches,
@@ -633,6 +635,10 @@ impl HttpRequest {
                     }
                 }
             }
+        }
+
+        if num_reqs > 5 {
+            println!("Loads of requests: {num_reqs}");
         }
 
         matches

--- a/photon/src/template.rs
+++ b/photon/src/template.rs
@@ -4,13 +4,13 @@ use std::{cell::RefCell, rc::Rc};
 use crate::{
     cache::{Cache, RegexCache},
     get_config,
-    http::{bake_ctx, get_bracket_pattern, Collector, CurlHandle, HttpReq, HttpResponse},
+    http::{CurlHandle, HttpReq, HttpResponse},
+    matcher::{Extractor, Matcher},
     template_executor::ExecutionOptions,
     PhotonContext,
 };
-use curl::easy::Easy2;
 use photon_dsl::{
-    dsl::{CompiledExpression, Value, VariableContainer},
+    dsl::{Value, VariableContainer},
     parser::compile_expression_validated,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -36,41 +36,6 @@ pub enum Method {
     OPTIONS,
 }
 
-#[derive(Debug, Clone)]
-pub enum MatcherType {
-    Word(Vec<String>),
-    DSL(Vec<CompiledExpression>),
-    Regex(Vec<u32>), // indicies into RegexCache
-    Status(Vec<u32>),
-}
-
-#[derive(Debug, Clone)]
-pub enum ExtractorType {
-    Matcher(MatcherType),
-    Kval(Vec<String>),
-}
-
-#[derive(Debug, Clone, Copy)]
-pub enum ExtractorPart {
-    HeaderCookie, // Either Header or Cookie, with Header having priority
-    Header,
-    Cookie,
-    // Response Parts
-    Body,
-    Raw,
-    All,
-    Response, // Seems to be an alias for All, https://github.com/projectdiscovery/nuclei/blob/dev/SYNTAX-REFERENCE.md#httprequest
-}
-
-#[derive(Debug, Clone, Copy)]
-pub enum ResponsePart {
-    Body,
-    Raw,
-    Header,
-    All,
-    Response, // Seems to be an alias for All, https://github.com/projectdiscovery/nuclei/blob/dev/SYNTAX-REFERENCE.md#httprequest
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum Condition {
@@ -86,26 +51,6 @@ pub struct Info {
     pub severity: Severity,
     pub reference: Vec<String>,
     pub tags: Vec<String>,
-}
-
-#[derive(Debug, Clone)]
-pub struct Matcher {
-    pub r#type: MatcherType,
-    pub name: Option<String>,
-    pub negative: bool,
-    pub group: Option<i64>, // Regex group number, None represents entire regex match
-    pub internal: bool,     // Used for workflows, matches, but does not print
-    pub part: ResponsePart,
-    pub condition: Condition,
-}
-
-#[derive(Debug, Clone)]
-pub struct Extractor {
-    pub r#type: ExtractorType,
-    pub name: Option<String>,
-    pub group: Option<i64>, // Regex group number, None represents entire regex match
-    pub internal: bool,     // Used for workflows, matches, but does not print
-    pub part: ExtractorPart,
 }
 
 type AttackPayloads = FxHashMap<String, Vec<Value>>;
@@ -206,247 +151,6 @@ impl Severity {
             Self::Low => "\x1b[0;90mlow\x1b[0m".to_string(),
             Self::Info => "\x1b[0;36minfo\x1b[0m".to_string(),
             Self::Unknown => "\x1b[0;90munknown\x1b[0m".to_string(),
-        }
-    }
-}
-
-fn extractor_part_to_string(data: &HttpResponse, part: ExtractorPart) -> String {
-    match part {
-        // Map 1:1 Extractor -> Response parts
-        ExtractorPart::All => response_to_string(data, ResponsePart::All),
-        ExtractorPart::Response => response_to_string(data, ResponsePart::Response),
-        ExtractorPart::Body => response_to_string(data, ResponsePart::Body),
-        ExtractorPart::Raw => response_to_string(data, ResponsePart::Raw),
-        // Cookies are in Headers, so HeaderCookie maps to Headers string
-        ExtractorPart::Header | ExtractorPart::HeaderCookie => {
-            response_to_string(data, ResponsePart::Header)
-        }
-
-        // Concatenated all cookie headers into a single string
-        ExtractorPart::Cookie => data
-            .headers
-            .iter()
-            .filter(|(key, _)| key.to_lowercase() == "set-cookie")
-            .map(|(_, value)| format!("{value}\n"))
-            .collect::<Vec<String>>()
-            .concat(),
-    }
-}
-
-// Get (Key, Value) pairs from cookies
-fn extractor_get_cookies(data: &HttpResponse) -> Vec<(String, String)> {
-    data.headers
-        .iter()
-        .filter(|(key, _)| key.to_lowercase() == "set-cookie")
-        .filter_map(|(_, value)| {
-            let cookie_kv = value.split(';').next().unwrap().split_once('=');
-            if let Some((key, value)) = cookie_kv {
-                // https://docs.projectdiscovery.io/templates/reference/extractors#kval-extractor
-                // Nuclei kval extractors don't support dashes, so we modify the key to conform to their spec
-                Some((String::from(key).replace('-', "_"), String::from(value)))
-            } else {
-                None
-            }
-        })
-        .collect::<Vec<(String, String)>>()
-}
-
-fn response_to_string(data: &HttpResponse, part: ResponsePart) -> String {
-    match part {
-        ResponsePart::All | ResponsePart::Response => {
-            // TODO: Actually return proper All, now easier using CURL
-            let mut parts = vec![];
-            data.headers
-                .iter()
-                .for_each(|(k, v)| parts.push(format!("{k}: {v}\n")));
-            parts.push(String::from_utf8_lossy(&data.body).into());
-            parts.concat()
-        }
-        ResponsePart::Body => String::from_utf8_lossy(&data.body).into(),
-        ResponsePart::Header => data
-            .headers
-            .iter()
-            .map(|(k, v)| format!("{k}: {v}\n"))
-            .collect::<Vec<String>>()
-            .concat(),
-        ResponsePart::Raw => {
-            // TODO: Actually return Raw
-            let mut parts = vec![];
-            data.headers
-                .iter()
-                .for_each(|(k, v)| parts.push(format!("{k}: {v}\n")));
-            parts.push(String::from_utf8_lossy(&data.body).into());
-            parts.concat()
-        }
-    }
-}
-
-fn contains_with_dsl(
-    haystack: &str,
-    needle: &str,
-    ctx: &Context,
-    photon_ctx: &PhotonContext,
-) -> bool {
-    if needle.contains("{{") && get_bracket_pattern().is_match(needle) {
-        if let Some(baked) = bake_ctx(needle, ctx, photon_ctx) {
-            haystack.contains(&baked)
-        } else {
-            false
-        }
-    } else {
-        haystack.contains(needle)
-    }
-}
-
-impl Matcher {
-    pub fn matches(
-        &self,
-        data: &HttpResponse,
-        regex_cache: &RegexCache,
-        context: &Context,
-        photon_ctx: &PhotonContext,
-    ) -> bool {
-        if matches!(self.r#type, MatcherType::Status(_)) {
-            return self.matches_status(data.status_code);
-        }
-
-        let data = response_to_string(data, self.part);
-        match &self.r#type {
-            MatcherType::DSL(dsls) => {
-                if self.condition == Condition::OR {
-                    dsls.iter().any(|expr| {
-                        let res = expr.execute(&context, &photon_ctx.functions);
-                        res.is_ok() && (res.unwrap() == Value::Boolean(true))
-                    })
-                } else {
-                    dsls.iter().all(|expr| {
-                        let res = expr.execute(&context, &photon_ctx.functions);
-                        res.is_ok() && (res.unwrap() == Value::Boolean(true))
-                    })
-                }
-            }
-            MatcherType::Regex(regexes) => {
-                if self.condition == Condition::OR {
-                    regexes
-                        .iter()
-                        .any(|pattern| regex_cache.matches(*pattern, &data))
-                } else {
-                    regexes
-                        .iter()
-                        .all(|pattern| regex_cache.matches(*pattern, &data))
-                }
-            }
-            MatcherType::Word(words) => {
-                if self.condition == Condition::OR {
-                    words
-                        .iter()
-                        .any(|needle| contains_with_dsl(&data, needle, context, photon_ctx))
-                } else {
-                    words
-                        .iter()
-                        .all(|needle| contains_with_dsl(&data, needle, context, photon_ctx))
-                }
-            }
-            MatcherType::Status(_) => false,
-        }
-    }
-
-    fn matches_status(&self, status: u32) -> bool {
-        match &self.r#type {
-            MatcherType::Status(statuses) => statuses.contains(&status),
-            _ => unreachable!("Cannot match status when type != MatcherType::Status"),
-        }
-    }
-}
-
-impl Extractor {
-    // TODO: Allow multiple returns, with matchers being ran with all permutations
-    // of all possible extracted values? That's the logic according to testing with Nuclei
-    // where the matcher is ran like this pseudo logic:
-    // values.iter().any(|val| {
-    //    context.set(name, val)
-    //    matcher.matches(context)
-    //})
-    // if either matches, both values are added into the match
-    pub fn extract(
-        &self,
-        data: &HttpResponse,
-        regex_cache: &RegexCache,
-        context: &Context,
-        photon_ctx: &PhotonContext,
-    ) -> Option<Value> {
-        match &self.r#type {
-            ExtractorType::Matcher(matcher) => {
-                if let MatcherType::Status(_) = matcher {
-                    return self.matches_status(data.status_code);
-                }
-
-                let data = extractor_part_to_string(data, self.part);
-                match &matcher {
-                    MatcherType::DSL(dsls) => dsls
-                        .iter()
-                        .filter_map(|expr| expr.execute(&context, &photon_ctx.functions).ok())
-                        .next(),
-                    MatcherType::Regex(regexes) => regexes
-                        .iter()
-                        .filter_map(|pattern| {
-                            regex_cache.match_group(
-                                *pattern,
-                                &data,
-                                self.group.unwrap_or(0) as usize,
-                            )
-                        })
-                        .next()
-                        .map(Value::String),
-                    MatcherType::Word(_) => {
-                        debug!("Extractor does not support Word matching");
-                        None
-                    }
-                    MatcherType::Status(_) => None,
-                }
-            }
-            ExtractorType::Kval(fields) => {
-                let cookies = extractor_get_cookies(data);
-                match self.part {
-                    ExtractorPart::Cookie | ExtractorPart::Header => {
-                        let kv = match self.part {
-                            ExtractorPart::Cookie => &cookies,
-                            ExtractorPart::Header => &data.headers,
-                            _ => unreachable!(),
-                        };
-                        for field in fields {
-                            if let Some((_, value)) = kv
-                                .iter()
-                                .find(|(k, _)| k.to_lowercase() == field.to_lowercase())
-                            {
-                                return Some(Value::String(value.clone()));
-                            }
-                        }
-                    }
-                    ExtractorPart::HeaderCookie => {
-                        for field in fields {
-                            for kv in [&data.headers, &cookies] {
-                                if let Some((_, value)) = kv
-                                    .iter()
-                                    .find(|(k, _)| k.to_lowercase() == field.to_lowercase())
-                                {
-                                    return Some(Value::String(value.clone()));
-                                }
-                            }
-                        }
-                    }
-                    _ => return None,
-                }
-                None
-            }
-        }
-    }
-
-    fn matches_status(&self, status: u32) -> Option<Value> {
-        match &self.r#type {
-            // TODO: Maybe this should be different/Not implemented for Extractor
-            ExtractorType::Matcher(MatcherType::Status(_)) => Some(Value::Int(status as i64)),
-            _ => unreachable!("Cannot match status when type != MatcherType::Status"),
         }
     }
 }
@@ -626,6 +330,7 @@ impl HttpRequest {
 
         for mut context in payload_contexts {
             for (idx, req) in self.path.iter().enumerate() {
+                // Signature will become nicer once ExecutorContext refactoring is done
                 if let Some(matches) = self.execute_single_request(
                     idx,
                     req,

--- a/photon/src/template.rs
+++ b/photon/src/template.rs
@@ -190,7 +190,7 @@ pub struct Template {
     pub dsl_variables: Vec<(String, String)>, // DSL variables, lazily compiled
 }
 
-// TODO: MatchResult value from extractor (figure out how we want to handle that logic as well)
+// TODO: MatchResult values from extractors (figure out how we want to handle that logic as well)
 #[derive(Debug)]
 pub struct MatchResult {
     pub name: String,

--- a/photon/src/template.rs
+++ b/photon/src/template.rs
@@ -576,12 +576,7 @@ impl HttpRequest {
             parent: Some(parent_ctx),
         };
 
-        if !self.payloads.is_empty() && self.path.len() > 1 {
-            println!("paths: {} - {}", self.path.len(), self.payloads.len());
-            println!("{:?}", self.payloads);
-        }
-
-        // TODO: add upper limit to amount of requests to send, don't want a single template doing hundreds of requests!
+        // TODO: Might add an upper limit to amount of requests to send, don't want a single template doing hundreds of requests!
 
         let attack_iter = AttackIterator::new(&self.payloads, self.attack_mode);
         let mut num_reqs = 0;
@@ -632,10 +627,6 @@ impl HttpRequest {
                     }
                 }
             }
-        }
-
-        if num_reqs > 5 {
-            println!("Loads of requests: {num_reqs}");
         }
 
         matches

--- a/photon/src/template_executor.rs
+++ b/photon/src/template_executor.rs
@@ -9,8 +9,10 @@ use url::Url;
 
 use crate::{
     cache::{Cache, RegexCache},
-    get_config, init_functions,
-    template::{Collector, Context, Template},
+    get_config,
+    http::Collector,
+    init_functions,
+    template::{Context, Template},
     template_loader::TemplateLoader,
     PhotonContext,
 };

--- a/photon/src/template_executor.rs
+++ b/photon/src/template_executor.rs
@@ -12,7 +12,7 @@ use crate::{
     get_config,
     http::Collector,
     init_functions,
-    template::{Context, Template},
+    template::{Context, ContextScope, Template},
     template_loader::TemplateLoader,
     PhotonContext,
 };
@@ -83,6 +83,7 @@ where
             ctx: Rc::from(RefCell::from(Context {
                 variables: FxHashMap::default(),
                 parent: None,
+                scope: ContextScope::Global,
             })),
             photon_ctx: PhotonContext {
                 functions: init_functions(),
@@ -104,6 +105,7 @@ where
             ctx: Rc::from(RefCell::from(Context {
                 variables: FxHashMap::default(),
                 parent: None,
+                scope: ContextScope::Global,
             })),
             photon_ctx: PhotonContext {
                 functions: init_functions(),

--- a/photon/src/template_loader.rs
+++ b/photon/src/template_loader.rs
@@ -284,7 +284,6 @@ pub fn parse_extractor(
     let extractor_name = yaml["name"].as_str();
     assert_fields(&[(extractor_type, "type")])?;
 
-    // TODO: Default extractor might be both Cookie + Header, so a secret third ExtractorPart
     let part = match extractor_part {
         Some(extractor_part) => {
             map_extractor_part(extractor_part).ok_or(TemplateError::InvalidValue("part".into()))?

--- a/photon/src/template_loader.rs
+++ b/photon/src/template_loader.rs
@@ -795,11 +795,16 @@ impl TemplateLoader {
             }
         }
         let keys: Vec<CacheKey> = tokens.keys().cloned().collect();
+        let mut num_cached = 0;
         for key in keys {
-            if *tokens.get(&key).unwrap() == 1 {
+            let num_tokens = *tokens.get(&key).unwrap();
+            if num_tokens == 1 {
                 tokens.remove(&key);
             }
+            num_cached += num_tokens;
         }
+        verbose!("Cached requests: {num_cached}");
+
         let cache = Cache::new(tokens);
         regex_cache.finalize();
         Self {

--- a/photon/src/template_loader.rs
+++ b/photon/src/template_loader.rs
@@ -12,10 +12,8 @@ use crate::{
     cache::{Cache, CacheKey, RegexCache},
     get_config,
     http::{get_bracket_pattern, HttpReq},
-    template::{
-        AttackMode, Condition, Extractor, ExtractorPart, ExtractorType, HttpRequest, Info, Matcher,
-        MatcherType, Method, ResponsePart, Severity, Template,
-    },
+    matcher::{Extractor, ExtractorPart, ExtractorType, Matcher, MatcherType, ResponsePart},
+    template::{AttackMode, Condition, HttpRequest, Info, Method, Severity, Template},
 };
 
 #[derive(Debug)]

--- a/photon/src/template_loader.rs
+++ b/photon/src/template_loader.rs
@@ -768,11 +768,6 @@ impl TemplateLoader {
         let mut tokens: HashMap<CacheKey, u16> = HashMap::new();
         for template in &loaded_templates {
             for http in &template.http {
-                // TODO: Handle cache with payloads + attack
-                // preferably before merging in payloads at all!
-                if !http.payloads.is_empty() {
-                    continue;
-                }
                 // TODO: Validate that the cache isn't accidentally leaking
                 // responses between same looking paths, where the paths are
                 // different due to some DSL stuff
@@ -782,6 +777,7 @@ impl TemplateLoader {
                 // 1. paths where dsl variable depends on something, e.g. extractor etc
                 // 2. paths where dsl variables are declared in the template
                 //    but are either static or deterministic, e.g. {{md5("test")}} but not {{rand_int(1, 100)}}
+                // UPDATE: Temporarily resolved by caching all requests with their post-bake urls
                 for request in &http.path {
                     tokens
                         .entry(CacheKey(

--- a/photon/src/template_loader.rs
+++ b/photon/src/template_loader.rs
@@ -4,6 +4,7 @@ use photon_dsl::{
     dsl::{CompiledExpression, Value},
     parser::compile_expression,
 };
+use rustc_hash::FxHashMap;
 use walkdir::WalkDir;
 use yaml_rust2::{Yaml, YamlLoader};
 
@@ -12,7 +13,7 @@ use crate::{
     get_config,
     http::{get_bracket_pattern, HttpReq},
     template::{
-        Condition, Extractor, ExtractorPart, ExtractorType, HttpRequest, Info, Matcher,
+        AttackMode, Condition, Extractor, ExtractorPart, ExtractorType, HttpRequest, Info, Matcher,
         MatcherType, Method, ResponsePart, Severity, Template,
     },
 };
@@ -251,8 +252,7 @@ fn parse_matcher_type(
                     .cloned()
                     .unwrap();
                 return Err(TemplateError::InvalidValue(format!(
-                    "Could not parse regex, parse output:\n{}",
-                    err
+                    "Could not parse regex, parse output:\n{err}"
                 )));
             }
 
@@ -562,11 +562,59 @@ pub fn parse_http(yaml: &Yaml, regex_cache: &mut RegexCache) -> Result<HttpReque
     } else {
         vec![]
     };
-
-    requests.append(&mut raw);
-
     let flattened_headers: Vec<String> = headers.iter().map(|(k, v)| format!("{k}: {v}")).collect();
 
+    let attack_mode = if let Some(attack) = yaml["attack"].as_str() {
+        match attack {
+            "batteringram" => AttackMode::Batteringram,
+            "clusterbomb" => AttackMode::Clusterbomb,
+            "pitchfork" => AttackMode::Pitchfork,
+            _ => {
+                return Err(TemplateError::InvalidValue(format!(
+                    "Invalid attack mode: {attack}"
+                )))
+            }
+        }
+    } else {
+        AttackMode::Batteringram
+    };
+
+    let mut payloads = FxHashMap::default();
+
+    if let Some(payloads_map) = yaml["payloads"].as_hash() {
+        for (key_yaml, values_yaml) in payloads_map {
+            let key = key_yaml.as_str();
+            let values = values_yaml.as_vec();
+
+            if key.is_none() || values.is_none() {
+                debug!(
+                    "Invalid payload! key or value is none! key: {:?}, value: {:?}",
+                    key, values
+                );
+                continue;
+            }
+
+            let key = key.unwrap();
+            let values: Vec<Value> = values
+                .unwrap()
+                .iter()
+                .filter_map(|value| {
+                    // Map value to Value::Something, string or int or sth
+                    if let Some(val) = value.as_str() {
+                        Some(Value::String(String::from(val)))
+                    } else if let Some(val) = value.as_i64() {
+                        Some(Value::Int(val))
+                    } else {
+                        value.as_bool().map(Value::Boolean)
+                    }
+                })
+                .collect();
+
+            payloads.insert(String::from(key), values);
+        }
+    }
+
+    requests.append(&mut raw);
     requests
         .iter_mut()
         .for_each(|req| req.headers = flattened_headers.clone());
@@ -575,6 +623,8 @@ pub fn parse_http(yaml: &Yaml, regex_cache: &mut RegexCache) -> Result<HttpReque
         matchers_condition,
         matchers,
         extractors,
+        attack_mode,
+        payloads,
         path: requests,
     })
 }

--- a/photon/src/template_loader.rs
+++ b/photon/src/template_loader.rs
@@ -768,6 +768,20 @@ impl TemplateLoader {
         let mut tokens: HashMap<CacheKey, u16> = HashMap::new();
         for template in &loaded_templates {
             for http in &template.http {
+                // TODO: Handle cache with payloads + attack
+                // preferably before merging in payloads at all!
+                if !http.payloads.is_empty() {
+                    continue;
+                }
+                // TODO: Validate that the cache isn't accidentally leaking
+                // responses between same looking paths, where the paths are
+                // different due to some DSL stuff
+                // e.g. two identical paths with {{randstr}} in different templates
+                // will have different random strings, thus possible inconsistency!
+                // Have two things to think about
+                // 1. paths where dsl variable depends on something, e.g. extractor etc
+                // 2. paths where dsl variables are declared in the template
+                //    but are either static or deterministic, e.g. {{md5("test")}} but not {{rand_int(1, 100)}}
                 for request in &http.path {
                     tokens
                         .entry(CacheKey(


### PR DESCRIPTION
Implements Attack mode & Payloads, allowing payloads in requests. Currently only supports pitchfork (and assumes all 3 attack modes are pitchfork)

Also implemented `base64`, `base64_py`, `mmh3` functions
Also added initial changes to allow DSL to work with raw byte response of a request, which will allow working with binary responses.