### PR TITLE
Reset cache between executions

### DIFF
--- a/photon/src/template_executor.rs
+++ b/photon/src/template_executor.rs
@@ -153,6 +153,7 @@ where
         base_url: &str,
         iter_fn: F,
     ) -> ScanResult<()> {
+        self.cache.reset();
         let mut curl = Easy2::new(Collector(Vec::new(), Vec::new()));
         {
             let parsed: Result<Url, _> = base_url.parse();


### PR DESCRIPTION
Resets cache at the start of each execution, otherwise we leak memory when photon is used in a non-ephemeral manner.